### PR TITLE
v6.0.0-alpha.4: Check in-memory cache before Redis

### DIFF
--- a/lib/asyncRedis.ts
+++ b/lib/asyncRedis.ts
@@ -31,6 +31,16 @@ export class AsyncRedis {
   del: (...keys: string[]) => Promise<number>;
 
   /**
+   * Get the TTL of a Redis key, in seconds.
+   *
+   * - Returns -2 if the key does not exist.
+   * - Returns -1 if the key exists but has no associated expire
+   *
+   * See https://redis.io/commands/ttl
+   */
+  ttl: (key: string) => Promise<number>;
+
+  /**
    * Evaluate a Redis expression.
    *
    * See https://redis.io/commands/eval
@@ -62,6 +72,7 @@ export class AsyncRedis {
     this.get = promisify(client.get).bind(client);
     this.set = promisify(client.set).bind(client);
     this.del = promisify(client.del).bind(client);
+    this.ttl = promisify(client.ttl).bind(client);
     this.eval = promisify(client.eval).bind(client);
     this.quit = promisify(client.quit).bind(client);
   }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
+import LRU from "lru-cache";
 import redis, { ClientOpts as RedisOpts } from "redis";
 
 import { AsyncRedis } from "./asyncRedis";
@@ -105,6 +106,16 @@ export class LockAndCache {
   private _cacheClient: AsyncRedis;
 
   /**
+   * An in-memory cache that deletes the "least recently used" (LRU) items.
+   *
+   * We use this to implement a fast caching layer that doesn't require hitting
+   * Redis in the simple case. We could use an all-in-one solution like
+   * `cache-manager`, but most of those libraries are huge and contain tons of
+   * callback-era code.
+   */
+  private _lruCache: LRU<string, string>;
+
+  /**
    * Create a new `LockAndCache`.
    *
    * ```
@@ -122,14 +133,17 @@ export class LockAndCache {
    * @param caches Caches to use. Defaults to `tieredCache()`.
    * @param lockClient Redis client to use for locking. Defaults to using
    * `DEFAULT_REDIS_OPTIONS`.
+   * @param memoryCacheSize How many items should we also cache in local memory?
    */
   constructor({
     lockClient = defaultRedisLockClient(),
     cacheClient = defaultRedisCacheClient(),
+    memoryCacheSize = 100,
   } = {}) {
     log.trace("creating LockAndCache");
     this._lockClient = new AsyncRedis(lockClient);
     this._cacheClient = new AsyncRedis(cacheClient);
+    this._lruCache = new LRU<string, string>({ max: memoryCacheSize });
   }
 
   /**
@@ -139,8 +153,15 @@ export class LockAndCache {
    */
   private async _cacheGet<T>(key: CacheKey): Promise<T> {
     const keyStr = serializeKey(key);
-    const serializedValue = await this._cacheClient.get(keyStr);
-    if (serializedValue === null) {
+
+    // Check our caches. `_lruCache` returns `null` on a cache miss, and
+    // `_cacheClient` returns `undefined`. `== null` is the idiomatic way to
+    // check for either.
+    let serializedValue: string | undefined | null = this._lruCache.get(keyStr);
+    if (serializeValue == null) {
+      serializedValue = await this._cacheClient.get(keyStr);
+    }
+    if (serializedValue == null) {
       throw new KeyNotFoundError(keyStr);
     }
     return deserializeValueOrError<T>(serializedValue);
@@ -153,6 +174,7 @@ export class LockAndCache {
     ttl: number
   ): Promise<void> {
     const keyStr = serializeKey(key);
+    this._lruCache.set(keyStr, serializedData, ttl * 1000);
     const r = await this._cacheClient.set(keyStr, serializedData, "ex", ttl);
     if (r !== "OK")
       throw new Error(`error caching at ${keyStr}: ${JSON.stringify(r)}`);

--- a/lib/lock.ts
+++ b/lib/lock.ts
@@ -240,7 +240,7 @@ export class Lock {
       this.key,
       this.secret,
       "nx",
-      "px",
+      "ex",
       this.heartbeatExpiresSecs
     );
     if (!r) {
@@ -252,7 +252,7 @@ export class Lock {
   private async extendRedisLock(): Promise<void> {
     const r = await this.redis.eval(
       `if redis.call("get", KEYS[1]) == ARGV[1] then
-        return redis.call("pexpire", KEYS[1], ARGV[2])
+        return redis.call("expire", KEYS[1], ARGV[2])
       else
         if redis.call("get", KEYS[1]) == false then
           return -1
@@ -267,7 +267,7 @@ export class Lock {
     );
     if (r === 0) {
       this.state = LockState.DiedWithRedisError;
-      throw new UnexpectedLockError("pexpire failed; this should NEVER happen");
+      throw new UnexpectedLockError("expire failed; this should NEVER happen");
     }
     if (r === -1) {
       this.state = LockState.DiedWithRedisError;

--- a/lib/lock.ts
+++ b/lib/lock.ts
@@ -18,7 +18,7 @@ function randomString(): string {
 function currentTimeInSeconds(): number {
   // This is a standard JavaScript trick to get seconds from a `Date` by
   // coercing it from a number-like object to a true number.
-  return +new Date();
+  return +new Date() / 1000;
 }
 
 /** A lock-related error. */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lock_and_cache",
-  "version": "6.0.0-alpha.5",
+  "version": "6.0.0-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lock_and_cache",
-  "version": "6.0.0-alpha.6",
+  "version": "6.0.0-alpha.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lock_and_cache",
-  "version": "6.0.0-alpha.3",
+  "version": "6.0.0-alpha.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lock_and_cache",
-  "version": "6.0.0-alpha.4",
+  "version": "6.0.0-alpha.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lock_and_cache",
-  "version": "6.0.0-alpha.2",
+  "version": "6.0.0-alpha.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -59,6 +59,12 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
       "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
+      "dev": true
+    },
+    "@types/lru-cache": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz",
+      "integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w==",
       "dev": true
     },
     "@types/mocha": {
@@ -1206,6 +1212,14 @@
         }
       }
     },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -2086,6 +2100,11 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "13.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lock_and_cache",
-  "version": "6.0.0-alpha.3",
+  "version": "6.0.0-alpha.4",
   "description": "Most caching libraries don't do locking, meaning that >1 process can be calculating a cached value at the same time. Since you presumably cache things because they cost CPU, database reads, or money, doesn't it make sense to lock while caching?",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lock_and_cache",
-  "version": "6.0.0-alpha.2",
+  "version": "6.0.0-alpha.3",
   "description": "Most caching libraries don't do locking, meaning that >1 process can be calculating a cached value at the same time. Since you presumably cache things because they cost CPU, database reads, or money, doesn't it make sense to lock while caching?",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",
@@ -35,6 +35,7 @@
     "dist/lib/**/*.js"
   ],
   "devDependencies": {
+    "@types/lru-cache": "^5.1.0",
     "@types/mocha": "^8.0.2",
     "@types/node": "^14.0.27",
     "@types/redis": "^2.8.25",
@@ -53,6 +54,7 @@
     "lint"
   ],
   "dependencies": {
+    "lru-cache": "^6.0.0",
     "redis": "^2.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lock_and_cache",
-  "version": "6.0.0-alpha.4",
+  "version": "6.0.0-alpha.5",
   "description": "Most caching libraries don't do locking, meaning that >1 process can be calculating a cached value at the same time. Since you presumably cache things because they cost CPU, database reads, or money, doesn't it make sense to lock while caching?",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lock_and_cache",
-  "version": "6.0.0-alpha.6",
+  "version": "6.0.0-alpha.7",
   "description": "Most caching libraries don't do locking, meaning that >1 process can be calculating a cached value at the same time. Since you presumably cache things because they cost CPU, database reads, or money, doesn't it make sense to lock while caching?",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lock_and_cache",
-  "version": "6.0.0-alpha.5",
+  "version": "6.0.0-alpha.6",
   "description": "Most caching libraries don't do locking, meaning that >1 process can be calculating a cached value at the same time. Since you presumably cache things because they cost CPU, database reads, or money, doesn't it make sense to lock while caching?",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/test/test.ts
+++ b/test/test.ts
@@ -19,7 +19,7 @@ describe("cache", () => {
   after(async () => cache.close());
 
   describe("cache.wrap(f)", () => {
-    const cachedDouble = cache.wrap({ ttl: 1 }, double);
+    const cachedDouble = cache.wrap({ ttl: 3 }, double);
 
     it("should cache the first call to f", async () => {
       let four = await cachedDouble(2);
@@ -43,7 +43,7 @@ describe("cache", () => {
       // with two caches.
       const cache2 = new LockAndCache();
       try {
-        const cachedDouble2 = cache2.wrap({ ttl: 1 }, double);
+        const cachedDouble2 = cache2.wrap({ ttl: 3 }, double);
         const results = await Promise.all([
           ...[10, 20, 20, 10].map((d) => cachedDouble(d)),
           ...[10, 20, 20, 10].map((d) => cachedDouble2(d)),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declaration": true /* Generates corresponding '.d.ts' file. */,
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */


### PR DESCRIPTION
We add support for a simple in-memory cache that we check before Redis,
which stores the 100 most recent items by default.

We chose `lru-cache` because it was popular and had adequate TypeScript
types. We could have used something like `cache-manager` to handle
multi-tier caching for us, but many of the most popular cache manager
modules are huge and complex.